### PR TITLE
(Fix) (Bug) Duplicate of titles in `org-roam-insert` [#2]

### DIFF
--- a/md-roam.el
+++ b/md-roam.el
@@ -113,9 +113,11 @@ of the title. 's-trim-left is used to remove it."
       (s-trim-left (match-string-no-properties 2)))))
 
 (defun md-roam--extract-titles (alias-list)
-  "Add markdown titles to the ALIAS-LIST returned form org-roam--extract-titles."
+  "Ignore ALIAS-LIST from org-roam--extract-titles if md-title is available.
+Add the markdown title to the ALIAS-LIST. If md-title is not available, return
+ALIAS-LIST as is."
   (let ((md-title (md-roam--extract-title-from-current-buffer)))
-    (if md-title (cons md-title alias-list)
+    (if md-title (setq alias-list md-title)
       alias-list)))
 
 (advice-add 'org-roam--extract-titles :filter-return #'md-roam--extract-titles)

--- a/md-roam.el
+++ b/md-roam.el
@@ -117,7 +117,7 @@ of the title. 's-trim-left is used to remove it."
 Add the markdown title to the ALIAS-LIST. If md-title is not available, return
 ALIAS-LIST as is."
   (let ((md-title (md-roam--extract-title-from-current-buffer)))
-    (if md-title (setq alias-list '(md-title))
+    (if md-title (setq alias-list (list md-title))
       alias-list)))
 
 (advice-add 'org-roam--extract-titles :filter-return #'md-roam--extract-titles)

--- a/md-roam.el
+++ b/md-roam.el
@@ -117,7 +117,7 @@ of the title. 's-trim-left is used to remove it."
 Add the markdown title to the ALIAS-LIST. If md-title is not available, return
 ALIAS-LIST as is."
   (let ((md-title (md-roam--extract-title-from-current-buffer)))
-    (if md-title (setq alias-list md-title)
+    (if md-title (setq alias-list '(md-title))
       alias-list)))
 
 (advice-add 'org-roam--extract-titles :filter-return #'md-roam--extract-titles)


### PR DESCRIPTION
(Fix) (Bug) Duplicate of titles in `org-roam-insert` [#2]

Note:
This fix introduces a new limitation:
Aliases for a file ([`#+ROAM_ALIAS`](https://org-roam.readthedocs.io/en/latest/anatomy/#file-aliases)) is not supported with `md-roam`. 

This can be put back, but requires some more time, if needed. 
I personally don't use this feature, so I'm fine with this "missing".

--- A bit more detail ---

The duplicate titles issue is caused by the change introduced to org-roam--extract-titles.
Upstream change (feat): optionally use headline as title (#538).
If the function cannot find org title (#+TITLE) then, it takes the first heading
(not necessarily the first line, as evident in my literature note with #+ROAM_REF.)

My fix this time is rather crude (need to come back to this); I'm overriding org-roam's
titles, including ALIASES, and add md-roam title (title:).

This means ALIASES are currently not supported. I don't use them. But it does not feel
very good as a long-term solution. In addition, this also means you cannot use the first
line as the title (But I don't think I want this as a feature; file name works when
title is missing for markdown files).