### PR TITLE
(feat) Add support for aliases in YAML front matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 1.1.1-md (TBD)
+## 1.1.2-md (TBD)
+* Add support aliases of a note with YAML matter property (roam_alias, ROAM_ALIAS, or #+ROAM_ALIAS)
+* Deprecate md-roam-title-regex, in favour of md-roam-regex-title
+
+## 1.1.1-md (2020-05-16)
 
 ### BREAKING CHANGES
 Upstream commit [`265182a`](https://github.com/org-roam/org-roam/commit/265182a698be6babcbb11718c2821c747b1cff52) compared to the last commit I tested [`0132546`](https://github.com/org-roam/org-roam/commit/0132546e56eb5cffd6cc52177b6ffbeab0d84743) introduces updates to database structure. I observe a change of version 2 to 5 in the matter of 15 days. I welcome the active development. 
@@ -12,7 +16,7 @@ Please take your usual caution of backing up your note and database files.
 * Use of upstream `org-roam-title-sources` variable
 
 ### Limitations
-* Does not support aliases for a file (#+ROAM_ALIAS) ([PR#5](https://github.com/nobiot/md-roam/pull/5))
+* ~~Does not support aliases for a file (#+ROAM_ALIAS) ([PR#5](https://github.com/nobiot/md-roam/pull/5))~~
 * Does not support (feat): optionally use headline as title [#538](https://github.com/jethrokuan/org-roam/pull/538) (See [#4](https://github.com/nobiot/md-roam/issues/4), [#5](https://github.com/nobiot/md-roam/pull/5))
 
 ## 1.1.0-md (2020-04-19)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use `org-roam` with markdown files by adding `md-roam` to it.
 ---
 
 ## Change Log
-Upstream `org-roam` is going through many changes. To catch up, `md-roam` is also changing heavily. I suggest to refer to Changelog maintained [here](CHANGELOG.md) for some breaking changes. Nothing should break your notes as `org-roam` is not designed to alter them, but it is a good practice to keep a back up of your notes, and the org-roam database file (usually named `org-roam.db` stored in your `org-roam-directory`).
+Upstream `org-roam` is going through many changes. To catch up, `md-roam` is also changing heavily. I suggest to refer to Changelog maintained [here](CHANGELOG.md) for some breaking changes. Nothing should break your notes as `org-roam` is not designed to alter them, but it is a good practice to keep a backup of your notes, and the org-roam database file (usually named `org-roam.db` stored in your `org-roam-directory`).
 
 ## Features of Org Roam Supported
 
@@ -30,12 +30,24 @@ Upstream `org-roam` is going through many changes. To catch up, `md-roam` is als
 - `title: Note's Title` in the YAML frontrunner delineated by `---`
 
   Currently no support for TOML or MMD syntax
-  
+
 - Backlink for the `[[wiki-link]]` syntax
 
 - `org-roam-insert` to insert `[[filename-without-extension]]` to create backlinks. 
 
 - pandoc style citation for cite links, such as `[@bibkey]`, `@bibkey` `-@bibkey`
+
+- Aliases of a note are defined in the YAML front matter with key `roam_alias` (case insensitive, and you can still follow the `org-roam` convention: `#+ROAM_ALIAS`). Aliases are specified following `org-roam` convention, in double quotation marks, separated by a space, as in `roam_alias: "alias 1" alias 2"`. Thus your front matter can look like this.
+
+```
+---
+title: this is the title: subtitle
+date: 2020-05-17
+other_key: value
+roam_alias: "alias 1" "alias 2" "alias 3"
+---
+```
+
 
 Most of the standard `org-roam` features are [should be] still supported. This means two things:
 
@@ -50,25 +62,27 @@ Most of the standard `org-roam` features are [should be] still supported. This m
 
 Although markdown files do not need `org-ref` it is required if you would like to use cite backlinks. 
 
-One notable difference may be that the cite file (the literature source) uses `#+ROAM_KEY` without the `cite:`. For example, in your literature note, you need do the following:
+One notable difference may be that the cite file (the literature source) uses `#+ROAM_KEY` without the `cite:` -- for this key, `md-roam` only supports the `org-roam` convention with `#+`. For example, in your literature note, you need do the following:
 
 ```
 title: How to Take Smart Notes: One Simple Technique to Boost Writing, Learning and Thinking – for Students, Academics and Nonfiction Book Writers
 #+ROAM_KEY: Ahrens2017
 ```
 
+Specifying the roam key with `cite:` as in `cite:Ahrens2017` should work, but in this case, the literature note itself ends up referencing itself, adding a cite-backlink to its own backlink buffer -- not a big problem, but you might find it a bit confusing.
+
+
 Known limitations are listed in the next section below.
 
 ## Features of Org Roam NOT Supported (Limitations)
 
-- Does not support aliases for a file (#+ROAM_ALIAS) ([#5](https://github.com/nobiot/md-roam/pull/5))
 - Does not support (feat): optionally use headline as title [#538](https://github.com/jethrokuan/org-roam/pull/538) (See [#4](https://github.com/nobiot/md-roam/issues/4), [#5](https://github.com/nobiot/md-roam/pull/5))
 
 ## Upstream Org Roam Commits Tested
   
 I have been trying to closely trail the upstream `org-roam` development; nevertheless, as it is being actively developed (awesome!), `md-roam` is usually lagging a bit behind. As of 2020-05-16, I am using it with upstream version 1.1.0 at commit [`265182a`](https://github.com/org-roam/org-roam/commit/265182a698be6babcbb11718c2821c747b1cff52) (latest as at the time of writing this).
 
-Please note, however, that Jethro and contributors have added good many new features since my last sync (on 2020-05-02). Among them, I have created issues in GitHub for testing the features I see potentially relevant for `md-roam`. 
+Please note, however, that Jethro and contributors have added good many new features since my last sync (on 2020-05-02). I have created issues in GitHub for testing these features I see potentially relevant for `md-roam`. 
 
 If anyone has some spare time, I would appreciate your helping with testing (and fixing issues). I'll be happy to have comments logged in issues in GitHub (it seems people are more comfortable with it than GitLab) -- I'll try to make explicit and community-friendly how we can use issues etc. as communication channels. 
 
@@ -93,8 +107,8 @@ You can download `md-roam.el` file, or clone this repository. Place the file in 
 (setq md-roam-file-extension-single "md") 
   ;set your markdown extension
   ;you can omit this if md, which is the default.
-(setq org-roam-title-sources '((mdtitle title headline) alias)
-  ;you need this nas of commit `095c771`.
+(setq org-roam-title-sources '((mdtitle title headline) (mdalias alias)
+  ;you need this as of commit `5f24103`.
 ```
 
 You also need to add your markdown extension to `org-roam-file-extensions` list -- this is for `org-roam` to know that you use the extension with `org-roam`.
@@ -103,10 +117,10 @@ You also need to add your markdown extension to `org-roam-file-extensions` list 
 (setq org-roam-file-extensions '("org" "md"))
 ```
 
-As of commit `095c771`, `md-roam` uses `org-roam-title-sources` variable to exract the titles of markdown files. This is done via function `org-roam-titles-mdtitle` defined in `md-roam.el`. The name is required by `org-roam`. Set the following variable. The important part is to set `mdtitle`. The sequence determines the priority (left-most is the highest priority).
+As of commit `5f24103`, `md-roam` uses `org-roam-title-sources` variable to exract the titles and aliases of markdown files. This is done via function `org-roam-titles-mdtitle` and `org-roam-titles-mdalias` respectively. They are defined in `md-roam.el`. Set the following variable. The important part is to set `mdtitle` and `mdalias`. The sequence determines the priority (left-most is the highest priority).
 
 ```
-(setq org-roam-title-sources '((mdtitle title headline) alias)
+(setq org-roam-title-sources '((mdtitle title headline) (mdalias alias)
 ```
 
 I use [Doom Emacs](https://github.com/hlissner/doom-emacs/blob/develop/docs/getting_started.org#installing-packages-from-external-sources).

--- a/md-roam.el
+++ b/md-roam.el
@@ -53,6 +53,13 @@
   ;If you change this to "\\(^`'\\{3\\}\\)$"), you shoul dbe able to
   ;support YAML matter ending with "```". I am not testing it, though.
 
+(defvar md-roam-regex-title
+  "\\(^title:[ \t]*\\)\\(.*\\)")
+
+(defvar md-roam-regex-aliases
+  ;; Assumed to be case insensitive
+  "\\(^.*ROAM_ALIAS:[ \t]*\\)\\(.*\\)")
+
 ;;;  Regexp for pandoc style citation for link extraction
 ;;;  Copy from pandco-mode to remove dependency
 ;;
@@ -124,7 +131,7 @@ It assumes:
 
     (let ((frontmatter (md-roam-get-yaml-front-matter)))
     (cond (frontmatter
-           (string-match "\\(^title:[ \t]*\\)\\(.*\\)" frontmatter)
+           (string-match md-roam-regex-title frontmatter)
            (list (match-string-no-properties 2 frontmatter))))))
 
 (defun org-roam--extract-titles-mdalias ()
@@ -132,7 +139,7 @@ It assumes:
 Return nil if none."
   (let ((frontmatter (md-roam-get-yaml-front-matter)))
     (cond (frontmatter
-           (string-match "\\(^.*ROAM_ALIAS:[ \t]*\\)\\(.*\\)" frontmatter)
+           (string-match md-roam-regex-aliases frontmatter)
            (org-roam--str-to-list (match-string-no-properties 2 frontmatter))))))
 
 (defun org-roam--extract-titles-mdheadline ()

--- a/md-roam.el
+++ b/md-roam.el
@@ -36,14 +36,14 @@
 ;;; Regexp for the beginning and ending of YAML front matter section
 ;;; In markdown-mode, beginning and ending are the same: "---".
 ;;; Separate regular expressions are defined here because in some
-;;; markdown conventions, the ending is delinated by "```".
+;;; markdown conventions, the ending is delineated by "```".
 ;;; This can be potentially supported setting a custom regexp for
-;;; the ending deliniator.
+;;; the ending delineator.
 
 ;;;; These regular expressions are modified versino of
 ;;;; `markdown-regex-yaml-metadata-border.
 ;;;; I am adding "^" to indicate that the a line needs to
-;;;; start with the deliniator.
+;;;; start with the delineator.
 
 (defvar md-roam-regex-yaml-font-matter-beginning
   "\\(^-\\{3\\}\\)$")
@@ -99,7 +99,7 @@ It is assumed to be a markdown file extension, e.g. .md, and .markdown."
 
 (defun md-roam-get-yaml-front-matter ()
   "Return the text of the YAML front matter of the current buffer.
-Return nil if the front matter does not exist, or incorrectly deliniated by
+Return nil if the front matter does not exist, or incorrectly delineated by
 '---'."
 
   (save-excursion
@@ -114,8 +114,8 @@ Return nil if the front matter does not exist, or incorrectly deliniated by
 (defun org-roam--extract-titles-mdtitle ()
   "Extract title from the current buffer (markdown file with YAML frontmatter).
 
-This function looks for the YAML frontmatter deliniator '---' begining of
-the buffer. No space is allowed before or after the deliniator.
+This function looks for the YAML frontmatter delineator '---' begining of
+the buffer. No space is allowed before or after the delineator.
 
 It assumes:
  (1) Current buffer is a markdonw file (but does not check it)

--- a/md-roam.el
+++ b/md-roam.el
@@ -5,8 +5,8 @@
 ;; Author: Noboru Ota <https://github.com/nobiot>, <https://gitlab.com/nobiot>
 ;; Maintainer: Noboru Ota <me@nobiot.com>
 ;; Created: April 15, 2020
-;; Modified: May 3, 2020
-;; Version: 1.1.0
+;; Modified: May 17, 2020
+;; Version: 1.2.1
 ;; Keywords:
 ;; Homepage: https://github.com/nobiot/md-roam, https://gitlab.com/nobiot/md-roam
 ;; Package-Requires: ((emacs 26.3) (cl-lib "0.5"))
@@ -24,21 +24,34 @@
 ;;; Code:
 ;;;
 
+(eval-when-compile (require 'subr-x))
 (require 'dash)
 (require 's)
 (require 'f)
 (declare-function org-roam--file-name-extension 'org-roam)
+(declare-function org-roam--str-to-list 'org-roam)
 
 ;;; Md-roam addtional variables
-;;; 
-;;; Regexp for title of markdown file in YAML frontmatter
-(defvar md-roam-title-regex
-  (concat "\\(^title:[[:blank:]]*\\)"   ; The line needs to begin with 'title:',
-                                        ; followed by 0-n spaces or tabs.
-                                        ; YAML might insist on whitespace, but
-                                        ; here we can be more lenient
-          "\\(.+\n\\)" ; Actual title string (1-n characters)
-          ))
+
+;;; Regexp for the beginning and ending of YAML front matter section
+;;; In markdown-mode, beginning and ending are the same: "---".
+;;; Separate regular expressions are defined here because in some
+;;; markdown conventions, the ending is delinated by "```".
+;;; This can be potentially supported setting a custom regexp for
+;;; the ending deliniator.
+
+;;;; These regular expressions are modified versino of
+;;;; `markdown-regex-yaml-metadata-border.
+;;;; I am adding "^" to indicate that the a line needs to
+;;;; start with the deliniator.
+
+(defvar md-roam-regex-yaml-font-matter-beginning
+  "\\(^-\\{3\\}\\)$")
+
+(defvar md-roam-regex-yaml-font-matter-ending
+  "\\(^-\\{3\\}\\)$")
+  ;If you change this to "\\(^`'\\{3\\}\\)$"), you shoul dbe able to
+  ;support YAML matter ending with "```". I am not testing it, though.
 
 ;;;  Regexp for pandoc style citation for link extraction
 ;;;  Copy from pandco-mode to remove dependency
@@ -84,6 +97,20 @@ It is assumed to be a markdown file extension, e.g. .md, and .markdown."
 ;;;  Extracting title from markdown files (YAML frontmatter)
 ;;;  Add advice to org-roam--extract-and-format-titles
 
+(defun md-roam-get-yaml-front-matter ()
+  "Return the text of the YAML front matter of the current buffer.
+Return nil if the front matter does not exist, or incorrectly deliniated by
+'---'."
+
+  (save-excursion
+    (goto-char (point-min))
+    (when-let
+        ((startpoint (re-search-forward
+                     md-roam-regex-yaml-font-matter-beginning nil t 1))
+         (endpoint (re-search-forward
+                    md-roam-regex-yaml-font-matter-ending nil t 1)))
+      (buffer-substring-no-properties startpoint endpoint))))
+
 (defun org-roam--extract-titles-mdtitle ()
   "Extract title from the current buffer (markdown file with YAML frontmatter).
 
@@ -93,26 +120,20 @@ the buffer. No space is allowed before or after the deliniator.
 It assumes:
  (1) Current buffer is a markdonw file (but does not check it)
  (2) It has title in the YAML frontmatter on top of the file
- (3) The format is 'title: The Document Title Value'
+ (3) The format is 'title: The Document Title Value'"
 
-The extraction is done via regex expresion in the variable defined in
-'md-roam-title-regex.
-It expects one or more space after the 'title:' key before the title value.
-If the space is not there, the title extracted will be ':title value'.
-
-At the moment, for some weird reason, the regex leaves one whitespace in front
-of the title. 's-trim-left is used to remove it."
-
-  (when
-    (save-excursion
-      (goto-char (point-min))
-      (re-search-forward "^---\n" 5 t nil))
-    (when (string-match md-roam-title-regex (buffer-string))
-      (list (s-trim-left (match-string-no-properties 2))))))
+    (let ((frontmatter (md-roam-get-yaml-front-matter)))
+    (cond (frontmatter
+           (string-match "\\(^title:[ \t]*\\)\\(.*\\)" frontmatter)
+           (list (match-string-no-properties 2 frontmatter))))))
 
 (defun org-roam--extract-titles-mdalias ()
-  "WIP: Return the aliases from the current buffer."
-  )
+  "Return list of aliases from the front matter section of the current buffer.
+Return nil if none."
+  (let ((frontmatter (md-roam-get-yaml-front-matter)))
+    (cond (frontmatter
+           (string-match "\\(^.*ROAM_ALIAS:[ \t]*\\)\\(.*\\)" frontmatter)
+           (org-roam--str-to-list (match-string-no-properties 2 frontmatter))))))
 
 (defun org-roam--extract-titles-mdheadline ()
   "WIP: Return the first headline of the current buffer."
@@ -228,6 +249,7 @@ follow this behaviour."
 (defun md-roam-add-message-to-db-build-cache (&optional force)
   "Add a message to the return message from `org-roam-db-build-cache'.
 This is to simply indicate that md-roam is active. FORCE does not do anythying."
+  (when force) ;do nothing
   (when md-roam-verbose
     (message "md-roam is active")))
 


### PR DESCRIPTION
Motivation #8.
Add support for aliases in YAML front matter.
Need more testing; it's late in the night.

This commit also changes the way regular expression is run. It should now delineate the front matter correctly with the beginning and ending `---`, and runs regular expression within it **only**. 

Aliases can also be found either the key `roam-alias:`,  or `#+ROAM_ALIAS:`.
The key should be case insensitive by default, but this should be controlled by Emacs's standard variable: `case-fold-search` (confirmed. It's buffer-specific. The default ignores case -- case insensitive. You can use `toggle-case-fold-search` to toggle).

The front matter should be something like:
```
---
title: this is the title: subtitle
date: 2020-05-17
other_key: value
roam_alias: "alias 1" "alias 2" "alias 3"
---
```