### PR TITLE
(feat) Allow roam_alias to be YAML formatted array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
 # Changelog
 
-## 1.2.1-md (TBD)
-* Add support aliases of a note with YAML matter property (roam_alias, ROAM_ALIAS, or #+ROAM_ALIAS) [#11]
+## 1.3.0-md (2020-06-07)
+
+### Features
+* Add support aliases of a note with YAML front matter property (roam_alias, ROAM_ALIAS, or #+ROAM_ALIAS) [#11][#21]
 * Deprecate md-roam-title-regex, in favour of md-roam-regex-title
 * Add support markdown headlines ("=", "-", and "#") [#15]
+
+### BREAKING CHANGES
+* If you use the `roam_alias` as the key to define a note's aliases, you can no longer use the Org-roam convention of space-separated "double quotation". You can still continue to use `#+ROAM_ALIAS` in this way, provided that it is used outside the YAML front matter. See README for more detail
+
+### Limitations
+* Only the flow style of the YAML sequence (array) is supported. The block style is not supported. See README for more detail
 
 ## 1.2.0-md (2020-05-16)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Md-roam extends the features and functions provided by [Org-roam](https://github
 ---
 
 ## Change Log
+
 Upstream Org-roam is going through many changes. To catch up, Md-roam is also changing heavily. I suggest to refer to Changelog maintained [here](CHANGELOG.md) for some breaking changes. Nothing should break your notes as Org-roam is not designed to alter them, but it is a good practice to keep a backup of your notes, and the org-roam database file (usually named `org-roam.db` stored in your `org-roam-directory`).
 
 ## Features of Org Roam Supported
@@ -27,9 +28,9 @@ Md-roam currently supports the following features for your markdown notes:
 
    You can define the markdown extension of your choice such as `.md` or `.markdown`.
    
-- `title: Note's Title` in the YAML frontrunner at the top of the markdown note delineated by `---`
+- `title: Note's Title` in the YAML front matter at the top of the markdown note delineated by `---`
 
-q  Currently no support for TOML or MMD syntax
+   Currently no support for TOML or MMD syntax
 
 - Backlink for the `[[wiki-link]]` syntax
 
@@ -37,15 +38,38 @@ q  Currently no support for TOML or MMD syntax
 
 - pandoc style citation for cite links, such as `[@bibkey]`, `@bibkey` `-@bibkey`
 
-- Aliases of a note are defined in the YAML front matter with key `roam_alias` (case insensitive, and you can still follow the Org-roam convention: `#+ROAM_ALIAS`). Aliases are specified following Org-roam convention, in double quotation marks, separated by a space, as in `roam_alias: "alias 1" alias 2"`. Thus your front matter can look like this.
+- Aliases of a note are defined in the YAML front matter with key `roam_alias` (case insensitive). Only a basic subset of the ["flow style" of YAML syntax](https://yaml.org/spec/1.2/spec.html#id2802662) is supported. The array needs to be defined in a single line. Separate each alias with a comma `,`; you can use single quotations or double quotations to surround each alias (see the example below).
 
-```
+  Regarding YAML syntax for the front matter, I think this is as far as I can get. I don't think I would be able to support the block style, or flow style with multiple lines with comments with `#`. I'd be happy if someone can PR this, if anyone needs that.
+
+  Alternatively, you can still follow the Org-roam convention: `#+ROAM_ALIAS` If you use this way, you define aliases following Org-roam convention, in double quotation marks, separated by a space. See illustrative examples below.
+  
+
+``` markdown
+
 ---
-title: this is the title: subtitle
+title: New way of definining Org-roam aliases within YAML front matter
 date: 2020-05-17
 other_key: value
-roam_alias: "alias 1" "alias 2" "alias 3"
+roam_alias: [ alias 1, 'alias 2', "alias 3" ]
 ---
+
+# Heading 1
+Body of this note continues...
+
+```
+
+``` markdown
+
+---
+title: This way of defining aliases still work
+date: 2020-06-07
+other_key: value
+---
+#+ROAM_ALIAS: "alias 1" "alias 2" "alias 3"
+
+# Heading 1
+Body of this note continues...
 ```
 
 - Extracting the first header text as the title when it is not given with YAML front matter in the markdown note. 

--- a/md-roam.el
+++ b/md-roam.el
@@ -61,8 +61,9 @@
   "\\(^.*ROAM_ALIAS:[ \t]*\\)\\(.*\\)")
 
 (defvar md-roam-regex-headline
-  (concat "\\(.*$\\)\n\\(^[=-]+$\\)" ;heading with '=' and '-'
-          "\\|"                      ; regex 'or'
+  (concat "^\s*\n"                   ;exludes YAML front matter
+          "\\(.*$\\)\n\\(^[=-]+$\\)" ;heading with '=' and '-'
+          "\\|"                      ;regex 'or'
           "\\(^#+ \\)\\(.*$\\)"))    ;heading with '#'
 
 ;;;  Regexp for pandoc style citation for link extraction
@@ -137,8 +138,8 @@ It assumes:
 
     (let ((frontmatter (md-roam-get-yaml-front-matter)))
     (cond (frontmatter
-           (string-match md-roam-regex-title frontmatter)
-           (list (match-string-no-properties 2 frontmatter))))))
+           (when (string-match md-roam-regex-title frontmatter)
+             (list (match-string-no-properties 2 frontmatter)))))))
 
 (defun org-roam--extract-titles-mdalias ()
   "Return list of aliases from the front matter section of the current buffer.
@@ -157,7 +158,7 @@ If not, return STR as is."
       str)))
 
 (defun md-roam--yaml-seq-to-list (seq)
-    "Return a list from YAML SEQ formatted in the flow style.
+  "Return a list from YAML SEQ formatted in the flow style.
 SEQ = sequence, it's an array. At the moment, only the flow style works.
 
 See the spec at https://yaml.org/spec/1.2/spec.html
@@ -175,8 +176,8 @@ See the spec at https://yaml.org/spec/1.2/spec.html
 ;; between the squeare bracket and the first/last item should not matter.
 ;; [item1, item2, item3] and [ item1, item2, item3 ] should be equally valid.
 
-    (let ((regexp "\\(\\[\s*\\)\\(.*\\)\\(\s*\\]\\)")
-          (separator ",\s*"))
+  (let ((regexp "\\(\\[\s*\\)\\(.*\\)\\(\s*\\]\\)")
+        (separator ",\s*"))
     (when (string-match regexp seq)
       (let ((items (split-string-and-unquote
                     (match-string-no-properties 2 seq) separator)))
@@ -187,11 +188,11 @@ See the spec at https://yaml.org/spec/1.2/spec.html
 It does not look at the header level; it always returns the first one
 defined by '=', '-', or '#'."
 
-(save-excursion
-  (goto-char (point-min))
-  (when (re-search-forward md-roam-regex-headline nil t 1)
-    (list (or (match-string-no-properties 1)
-              (match-string-no-properties 4))))))
+  (save-excursion
+    (goto-char (point-min))
+    (when (re-search-forward md-roam-regex-headline nil t 1)
+      (list (or (match-string-no-properties 1)
+                (match-string-no-properties 4))))))
 
 ;;; Extract links in markdown file (wiki and pandocy-style cite)
 ;;; Add advice to org-roam--extract-links

--- a/md-roam.el
+++ b/md-roam.el
@@ -5,11 +5,11 @@
 ;; Author: Noboru Ota <https://github.com/nobiot>, <https://gitlab.com/nobiot>
 ;; Maintainer: Noboru Ota <me@nobiot.com>
 ;; Created: April 15, 2020
-;; Modified: May 17, 2020
-;; Version: 1.2.1
+;; Modified: June 06, 2020
+;; Version: 1.3.0
 ;; Keywords:
 ;; Homepage: https://github.com/nobiot/md-roam, https://gitlab.com/nobiot/md-roam
-;; Package-Requires: ((emacs 26.3) (cl-lib "0.5"))
+;; Package-Requires: ((emacs 26.3) (dash) (s) (f) (org-roam))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
Motivation: #19
YAML formatted array, for example:
roam_alias: ['alias 1', 'alias 2', 'alias 3']

**Test 1.** Three different ways to define items in a YAML array (sequence)
![image](https://user-images.githubusercontent.com/12507865/83953448-d00b5b80-a840-11ea-980f-aaeb867b62a4.png)

**Regression Test 1.** Markdown file with the Org convention and outside the YAML front matter
![image](https://user-images.githubusercontent.com/12507865/83953477-0c3ebc00-a841-11ea-9977-4cc2bab207d1.png)

**Regression Test 2.** Org file with the Org convention
![image](https://user-images.githubusercontent.com/12507865/83953509-3db78780-a841-11ea-9354-a3148488b47c.png)

**Regression Test 3.** Markdown file. Aliases defined by the Org convention need to be outside the YAML front matter. If inside, they need to be defined by a YAML array
![image](https://user-images.githubusercontent.com/12507865/83953629-11503b00-a842-11ea-9a36-a327287c315f.png)


