### PR TITLE
(fix) format-link should support TYPE parameter

### DIFF
--- a/md-roam.el
+++ b/md-roam.el
@@ -432,8 +432,8 @@ It is meant to be used with `advice-add' :around."
 ;;;; Adapt behaviour of org-roam-insert
 ;;;; Add advice to 'org-roam--format-link
 
-(defun md-roam--format-link (target &optional description)
-  "Formats a [[wikilink]] for a given file TARGET and link DESCRIPTION.
+(defun md-roam--format-link (target &optional description type)
+  "Formats a [[wikilink]] for a given file TARGET, link DESCRIPTION and link TYPE.
 Add advice to 'org-roam--format-link' within 'org-roam-insert'.
 Customize `md-roam-file-extension-single' to define the extesion (e.g. md) that
 follows this behaviour."


### PR DESCRIPTION
This pr should fix issue #34. In [this commit](https://github.com/org-roam/org-roam/commit/0318983cac2ae8e75eec37f234aac3e5b8d15e53), org-roam add an extra `type` parameter to `org-roam--format-link` function.