### PR TITLE
Evaluate titles within documents that have hard-wrapped text.

### DIFF
--- a/md-roam.el
+++ b/md-roam.el
@@ -394,6 +394,7 @@ If HASH is non-nil, use that as the file's hash without recalculating it."
         (while (re-search-forward "\\[\\[\\([^]]+\\)\\]\\]" nil t)
           (let* ((name (match-string-no-properties 1))
                  (node (or (org-roam-node-from-title-or-alias name)
+                           (org-roam-node-from-title-or-alias (replace-regexp-in-string "[\n ]+" " " name))
                            (org-roam-node-create :id name)))
                  (path (org-roam-node-id node)))
             ;; insert to cache the link only there is a file for the


### PR DESCRIPTION
I hard-wrap my text. This creates problems resolving org-roam nodes via title when the wikilink is split between two lines. This one-liner seems to fix my issues.

Thank you so much for this package! It's been fantastic so far.