### PR TITLE
Do not depend on arg numbers for `md-roam-id-get`

### DIFF
--- a/md-roam.el
+++ b/md-roam.el
@@ -642,7 +642,7 @@ invalid-regexp \"Invalid regular expression\"."
 ;;------------------------------------------------------------------------------
 ;;;;; Functions for `org-roam-capture'
 
-(defun md-roam-id-get (&optional _pom _create _prefix)
+(defun md-roam-id-get (&rest _args)
   "This is meant to replace `org-id-get' for markdown buffers.
 `org-roam-capture' process tries to create and add ID in the
 Org's property drawer for a new file is being created.  For


### PR DESCRIPTION
With recent change of org mode, https://github.com/emacsmirror/org/commit/95554543b98513fb807a72a9fc5256e92c4cece0, the number of optional arguments of `org-id-get` has changed to 4; so `md-roam-id-get` causes trouble.

This PR makes `md-roam-id-get` argument number agnostic to resolve the error.